### PR TITLE
feat(dark): fix color mapping of dark mode's border-color-primary

### DIFF
--- a/public/styles/dark.css
+++ b/public/styles/dark.css
@@ -35,7 +35,7 @@
     --text-color-on-warning: var(--warning-yellow-500);
     --text-color-on-placeholder: var(--high-tide);
 
-    --border-color-primary: var(--gravel-rocks);
+    --border-color-primary: var(--harbor-gray);
     --border-color-secondary: var(--fifty-shades);
     --border-color-input: var(--gravel-rocks);
     --border-color-focus: var(--coastal-shore);


### PR DESCRIPTION
There's a wrong mapping according to the design system, which causes two `border` colors to be the same.
[CU-20dk7jn](https://app.clickup.com/t/20dk7jn)
![image](https://user-images.githubusercontent.com/30905362/148187280-e74dcd72-53ed-4ddc-954f-4e74e1eb241f.png)
