### PR TITLE
fix: remove opacity from feet-in-the-water

### DIFF
--- a/public/styles/colors.css
+++ b/public/styles/colors.css
@@ -1,6 +1,6 @@
 :root {
     /*** Primary ***/
-    --feet-in-the-water: rgba(229, 236, 255, 0.6);
+    --feet-in-the-water: rgb(229, 236, 255);
 
     --coastal-shore: #4293F3;
 


### PR DESCRIPTION
it caused some unexpected issues on the app, revealing underneath elements, looking badly on elements with no background underneath, etc.

@shujuuu FYI