### PR TITLE
Vue vite upgrade

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "dependencies": {
     "floating-vue": "^2.0.0-beta.17",
     "fontaweswimm": "https://github.com/swimmio/fontaweswimm#1.1.23",
-    "vue": "^3.2.33"
+    "vue": "^3.1.0"
   },
   "devDependencies": {
     "@commitlint/cli": "^17.0.0",
@@ -30,27 +30,27 @@
     "@rushstack/eslint-patch": "^1.1.0",
     "@semantic-release/changelog": "^6.0.1",
     "@semantic-release/git": "^10.0.1",
-    "@vitejs/plugin-vue": "^2.3.1",
+    "@vitejs/plugin-vue": "^3.0.1",
     "@vue/eslint-config-prettier": "^7.0.0",
     "@vue/test-utils": "^2.0.0-rc.20",
     "@vuepress/plugin-register-components": "2.0.0-beta.48",
     "@vueuse/core": "^9.1.0",
     "cz-conventional-changelog": "3.3.0",
     "eslint": "^8.5.0",
-    "eslint-plugin-vue": "^8.2.0",
+    "eslint-plugin-vue": "^9.3.0",
     "glob-promise": "^5.0.0",
     "husky": "^8.0.1",
     "jsdom": "^19.0.0",
     "markdown-it-container": "^3.0.0",
     "prettier": "^2.5.1",
     "semantic-release": "^19.0.2",
-    "vite": "^2.9.5",
+    "vite": "^3.0.4",
     "vitest": "^0.19.1",
     "vue-docgen-api": "^4.50.0",
     "vuepress": "2.0.0-beta.48"
   },
   "peerDependencies": {
-    "vue": "^3.2.33"
+    "vue": "^3.1.0"
   },
   "config": {
     "commitizen": {

--- a/src/components/Breadcrumbs/Breadcrumb/__snapshots__/Breadcrumb.spec.js.snap
+++ b/src/components/Breadcrumbs/Breadcrumb/__snapshots__/Breadcrumb.spec.js.snap
@@ -1,17 +1,17 @@
 // Vitest Snapshot v1
 
 exports[`Breadcrumb > should render item 1`] = `
-"<div class=\\"breadcrumb\\" data-v-3e997d90=\\"\\">
-  <div class=\\"content\\" data-v-3e997d90=\\"\\">
-    <icon-stub name=\\"g\\" nopadding=\\"false\\" data-v-3e997d90=\\"\\"></icon-stub><span class=\\"name\\" data-v-3e997d90=\\"\\">g</span>
+"<div class=\\"breadcrumb\\" data-v-4117cb18=\\"\\">
+  <div class=\\"content\\" data-v-4117cb18=\\"\\">
+    <icon-stub name=\\"g\\" nopadding=\\"false\\" data-v-4117cb18=\\"\\"></icon-stub><span class=\\"name\\" data-v-4117cb18=\\"\\">g</span>
   </div>
 </div>"
 `;
 
 exports[`Breadcrumb > should render router-link for link 1`] = `
-"<div class=\\"breadcrumb\\" data-v-3e997d90=\\"\\">
-  <router-link to=\\"/g\\" class=\\"content has-link\\" data-v-3e997d90=\\"\\">
-    <icon-stub name=\\"g\\" nopadding=\\"false\\" data-v-3e997d90=\\"\\"></icon-stub><span class=\\"name\\" data-v-3e997d90=\\"\\">g</span>
+"<div class=\\"breadcrumb\\" data-v-4117cb18=\\"\\">
+  <router-link to=\\"/g\\" class=\\"content has-link\\" data-v-4117cb18=\\"\\">
+    <icon-stub name=\\"g\\" nopadding=\\"false\\" data-v-4117cb18=\\"\\"></icon-stub><span class=\\"name\\" data-v-4117cb18=\\"\\">g</span>
   </router-link>
 </div>"
 `;

--- a/src/components/Breadcrumbs/__snapshots__/Breadcrumbs.spec.js.snap
+++ b/src/components/Breadcrumbs/__snapshots__/Breadcrumbs.spec.js.snap
@@ -1,16 +1,16 @@
 // Vitest Snapshot v1
 
 exports[`Breadcrumbs > renders breadcrumbs with links 1`] = `
-"<div class=\\"breadcrumbs\\" data-v-7650ef71=\\"\\">
-  <breadcrumb-stub name=\\"g\\" icon=\\"g\\" link=\\"/g\\" class=\\"item\\" data-v-7650ef71=\\"\\"></breadcrumb-stub>
-  <breadcrumb-stub name=\\"b\\" icon=\\"b\\" link=\\"/b\\" class=\\"item\\" data-v-7650ef71=\\"\\"></breadcrumb-stub>
+"<div class=\\"breadcrumbs\\" data-v-490673c1=\\"\\">
+  <breadcrumb-stub name=\\"g\\" icon=\\"g\\" link=\\"/g\\" class=\\"item\\" data-v-490673c1=\\"\\"></breadcrumb-stub>
+  <breadcrumb-stub name=\\"b\\" icon=\\"b\\" link=\\"/b\\" class=\\"item\\" data-v-490673c1=\\"\\"></breadcrumb-stub>
 </div>"
 `;
 
 exports[`Breadcrumbs > renders default Breadcrumbs 1`] = `
-"<div class=\\"breadcrumbs\\" data-v-7650ef71=\\"\\">
-  <breadcrumb-stub name=\\"g\\" icon=\\"g\\" class=\\"item\\" data-v-7650ef71=\\"\\"></breadcrumb-stub>
+"<div class=\\"breadcrumbs\\" data-v-490673c1=\\"\\">
+  <breadcrumb-stub name=\\"g\\" icon=\\"g\\" class=\\"item\\" data-v-490673c1=\\"\\"></breadcrumb-stub>
 </div>"
 `;
 
-exports[`Breadcrumbs > renders empty array 1`] = `"<div class=\\"breadcrumbs\\" data-v-7650ef71=\\"\\"></div>"`;
+exports[`Breadcrumbs > renders empty array 1`] = `"<div class=\\"breadcrumbs\\" data-v-490673c1=\\"\\"></div>"`;

--- a/src/components/Typography/SwText.vue
+++ b/src/components/Typography/SwText.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { computed, defineProps } from 'vue';
+import { computed } from 'vue';
 import {
   FONT_FAMILY,
   VARIANTS,

--- a/yarn.lock
+++ b/yarn.lock
@@ -798,10 +798,15 @@
   resolved "https://registry.yarnpkg.com/@types/web-bluetooth/-/web-bluetooth-0.0.15.tgz#d60330046a6ed8a13b4a53df3813c44942ebdf72"
   integrity sha512-w7hEHXnPMEZ+4nGKl/KDRVpxkwYxYExuHOYXyzIzCDzEZ9ZCGMAewulr9IqJu2LR4N37fcnb1XVeuZ09qgOxhA==
 
-"@vitejs/plugin-vue@^2.3.1", "@vitejs/plugin-vue@^2.3.3":
+"@vitejs/plugin-vue@^2.3.3":
   version "2.3.3"
   resolved "https://registry.yarnpkg.com/@vitejs/plugin-vue/-/plugin-vue-2.3.3.tgz#fbf80cc039b82ac21a1acb0f0478de8f61fbf600"
   integrity sha512-SmQLDyhz+6lGJhPELsBdzXGc+AcaT8stgkbiTFGpXPe8Tl1tJaBw1A6pxDqDuRsVkD8uscrkx3hA7QDOoKYtyw==
+
+"@vitejs/plugin-vue@^3.0.1":
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/@vitejs/plugin-vue/-/plugin-vue-3.0.3.tgz#7e3e401ccb30b4380d2279d9849281413f1791ef"
+  integrity sha512-U4zNBlz9mg+TA+i+5QPc3N5lQvdUXENZLO2h0Wdzp56gI1MWhqJOv+6R+d4kOzoaSSq6TnGPBdZAXKOe4lXy6g==
 
 "@vue/compiler-core@3.2.37":
   version "3.2.37"
@@ -1236,6 +1241,11 @@ acorn@^8.4.1, acorn@^8.5.0, acorn@^8.7.1:
   version "8.7.1"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.7.1.tgz#0197122c843d1bf6d0a5e83220a788f278f63c30"
   integrity sha512-Xx54uLJQZ19lKygFXOWsscKUbsBZW0CPykPhVQdhIeIwrbPmJzqeASDInc8nKBnp/JT6igTs82qPXz069H8I/A==
+
+acorn@^8.8.0:
+  version "8.8.0"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.8.0.tgz#88c0187620435c7f6015803f5539dae05a9dbea8"
+  integrity sha512-QOxyigPVrpZ2GXT+PFyZTl6TtOFc5egxHIP9IlQ+RbupQuX4RkT/Bee4/kQuC02Xkzg84JcT7oLYtDIQxp+v7w==
 
 agent-base@6, agent-base@^6.0.2:
   version "6.0.2"
@@ -2550,19 +2560,20 @@ eslint-plugin-prettier@^4.0.0:
   dependencies:
     prettier-linter-helpers "^1.0.0"
 
-eslint-plugin-vue@^8.2.0:
-  version "8.7.1"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-vue/-/eslint-plugin-vue-8.7.1.tgz#f13c53547a0c9d64588a675cc5ecc6ccaf63703f"
-  integrity sha512-28sbtm4l4cOzoO1LtzQPxfxhQABararUb1JtqusQqObJpWX2e/gmVyeYVfepizPFne0Q5cILkYGiBoV36L12Wg==
+eslint-plugin-vue@^9.3.0:
+  version "9.3.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-vue/-/eslint-plugin-vue-9.3.0.tgz#c3f5ce515dae387e062428725c5cf96098d9da0b"
+  integrity sha512-iscKKkBZgm6fGZwFt6poRoWC0Wy2dQOlwUPW++CiPoQiw1enctV2Hj5DBzzjJZfyqs+FAXhgzL4q0Ww03AgSmQ==
   dependencies:
     eslint-utils "^3.0.0"
     natural-compare "^1.4.0"
     nth-check "^2.0.1"
     postcss-selector-parser "^6.0.9"
     semver "^7.3.5"
-    vue-eslint-parser "^8.0.1"
+    vue-eslint-parser "^9.0.1"
+    xml-name-validator "^4.0.0"
 
-eslint-scope@^7.0.0, eslint-scope@^7.1.1:
+eslint-scope@^7.1.1:
   version "7.1.1"
   resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-7.1.1.tgz#fff34894c2f65e5226d3041ac480b4513a163642"
   integrity sha512-QKQM/UXpIiHcLqJ5AOyIW7XZmzjkzQXYE54n1++wb0u9V/abW3l9uQnxX8Z5Xd18xyKIMTUAyQ0k1e8pz6LUrw==
@@ -2582,7 +2593,7 @@ eslint-visitor-keys@^2.0.0:
   resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz#f65328259305927392c938ed44eb0a5c9b2bd303"
   integrity sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==
 
-eslint-visitor-keys@^3.1.0, eslint-visitor-keys@^3.3.0:
+eslint-visitor-keys@^3.3.0:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-3.3.0.tgz#f6480fa6b1f30efe2d1968aa8ac745b862469826"
   integrity sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA==
@@ -2628,7 +2639,16 @@ eslint@^8.5.0:
     text-table "^0.2.0"
     v8-compile-cache "^2.0.3"
 
-espree@^9.0.0, espree@^9.3.2:
+espree@^9.3.1:
+  version "9.3.3"
+  resolved "https://registry.yarnpkg.com/espree/-/espree-9.3.3.tgz#2dd37c4162bb05f433ad3c1a52ddf8a49dc08e9d"
+  integrity sha512-ORs1Rt/uQTqUKjDdGCyrtYxbazf5umATSf/K4qxjmZHORR6HJk+2s/2Pqe+Kk49HHINC/xNIrGfgh8sZcll0ng==
+  dependencies:
+    acorn "^8.8.0"
+    acorn-jsx "^5.3.2"
+    eslint-visitor-keys "^3.3.0"
+
+espree@^9.3.2:
   version "9.3.2"
   resolved "https://registry.yarnpkg.com/espree/-/espree-9.3.2.tgz#f58f77bd334731182801ced3380a8cc859091596"
   integrity sha512-D211tC7ZwouTIuY5x9XnS0E9sWNChB7IYKX/Xp5eQj3nFXhqmiUDB9q27y76oFl8jTg3pXcQx/bpxMfs3CIZbA==
@@ -4885,6 +4905,15 @@ postcss@^8.1.10, postcss@^8.4.13, postcss@^8.4.14:
     picocolors "^1.0.0"
     source-map-js "^1.0.2"
 
+postcss@^8.4.16:
+  version "8.4.16"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.4.16.tgz#33a1d675fac39941f5f445db0de4db2b6e01d43c"
+  integrity sha512-ipHE1XBvKzm5xI7hiHCZJCSugxvsdq2mPnsq5+UF+VHCjiBvtDrlxJfMBToWaP9D5XlgNmcFGqoHmUn0EYEaRQ==
+  dependencies:
+    nanoid "^3.3.4"
+    picocolors "^1.0.0"
+    source-map-js "^1.0.2"
+
 prelude-ls@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.2.1.tgz#debc6489d7a6e6b0e7611888cec880337d316396"
@@ -5314,6 +5343,13 @@ rimraf@^3.0.0, rimraf@^3.0.2:
   dependencies:
     glob "^7.1.3"
 
+"rollup@>=2.75.6 <2.77.0 || ~2.77.0":
+  version "2.77.3"
+  resolved "https://registry.yarnpkg.com/rollup/-/rollup-2.77.3.tgz#8f00418d3a2740036e15deb653bed1a90ee0cc12"
+  integrity sha512-/qxNTG7FbmefJWoeeYJFbHehJ2HNWnjkAFRKzWN/45eNBBF/r8lo992CwcJXEzyVxs5FmfId+vTSTQDb+bxA+g==
+  optionalDependencies:
+    fsevents "~2.3.2"
+
 rollup@^2.59.0, rollup@^2.75.0:
   version "2.75.7"
   resolved "https://registry.yarnpkg.com/rollup/-/rollup-2.75.7.tgz#221ff11887ae271e37dcc649ba32ce1590aaa0b9"
@@ -5437,7 +5473,7 @@ semver-regex@^3.1.2:
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.1.tgz#a954f931aeba508d307bbf069eff0c01c96116f7"
   integrity sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==
 
-semver@7.3.7, semver@^7.0.0, semver@^7.1.1, semver@^7.1.2, semver@^7.3.2, semver@^7.3.4, semver@^7.3.5, semver@^7.3.7:
+semver@7.3.7, semver@^7.0.0, semver@^7.1.1, semver@^7.1.2, semver@^7.3.2, semver@^7.3.4, semver@^7.3.5, semver@^7.3.6, semver@^7.3.7:
   version "7.3.7"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.7.tgz#12c5b649afdbf9049707796e22a4028814ce523f"
   integrity sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==
@@ -6064,7 +6100,19 @@ validate-npm-package-name@^4.0.0:
   optionalDependencies:
     fsevents "~2.3.2"
 
-vite@^2.9.5, vite@~2.9.9:
+vite@^3.0.4:
+  version "3.0.8"
+  resolved "https://registry.yarnpkg.com/vite/-/vite-3.0.8.tgz#aa095ad8e3e5da46d9ec7e878f262678965d6531"
+  integrity sha512-AOZ4eN7mrkJiOLuw8IA7piS4IdOQyQCA81GxGsAQvAZzMRi9ZwGB3TOaYsj4uLAWK46T5L4AfQ6InNGlxX30IQ==
+  dependencies:
+    esbuild "^0.14.47"
+    postcss "^8.4.16"
+    resolve "^1.22.1"
+    rollup ">=2.75.6 <2.77.0 || ~2.77.0"
+  optionalDependencies:
+    fsevents "~2.3.2"
+
+vite@~2.9.9:
   version "2.9.12"
   resolved "https://registry.yarnpkg.com/vite/-/vite-2.9.12.tgz#b1d636b0a8ac636afe9d83e3792d4895509a941b"
   integrity sha512-suxC36dQo9Rq1qMB2qiRorNJtJAdxguu5TMvBHOc/F370KvqAe9t48vYp+/TbPKRNrMh/J55tOUmkuIqstZaew==
@@ -6118,18 +6166,18 @@ vue-docgen-api@^4.50.0:
     ts-map "^1.0.3"
     vue-inbrowser-compiler-utils "^4.50.0"
 
-vue-eslint-parser@^8.0.1:
-  version "8.3.0"
-  resolved "https://registry.yarnpkg.com/vue-eslint-parser/-/vue-eslint-parser-8.3.0.tgz#5d31129a1b3dd89c0069ca0a1c88f970c360bd0d"
-  integrity sha512-dzHGG3+sYwSf6zFBa0Gi9ZDshD7+ad14DGOdTLjruRVgZXe2J+DcZ9iUhyR48z5g1PqRa20yt3Njna/veLJL/g==
+vue-eslint-parser@^9.0.1:
+  version "9.0.3"
+  resolved "https://registry.yarnpkg.com/vue-eslint-parser/-/vue-eslint-parser-9.0.3.tgz#0c17a89e0932cc94fa6a79f0726697e13bfe3c96"
+  integrity sha512-yL+ZDb+9T0ELG4VIFo/2anAOz8SvBdlqEnQnvJ3M7Scq56DvtjY0VY88bByRZB0D4J0u8olBcfrXTVONXsh4og==
   dependencies:
-    debug "^4.3.2"
-    eslint-scope "^7.0.0"
-    eslint-visitor-keys "^3.1.0"
-    espree "^9.0.0"
+    debug "^4.3.4"
+    eslint-scope "^7.1.1"
+    eslint-visitor-keys "^3.3.0"
+    espree "^9.3.1"
     esquery "^1.4.0"
     lodash "^4.17.21"
-    semver "^7.3.5"
+    semver "^7.3.6"
 
 vue-inbrowser-compiler-demi@^4.50.0:
   version "4.50.0"
@@ -6156,7 +6204,7 @@ vue-router@^4.0.15:
   dependencies:
     "@vue/devtools-api" "^6.0.0"
 
-vue@^3.2.33, vue@^3.2.36:
+vue@^3.1.0, vue@^3.2.36:
   version "3.2.37"
   resolved "https://registry.yarnpkg.com/vue/-/vue-3.2.37.tgz#da220ccb618d78579d25b06c7c21498ca4e5452e"
   integrity sha512-bOKEZxrm8Eh+fveCqS1/NkG/n6aMidsI6hahas7pa0w/l7jkbssJVsRhVDs07IdDq7h9KHswZOgItnwJAgtVtQ==


### PR DESCRIPTION
This fixes the lint errors. We used incorrect versions of the Vue's Vite plugin and regardless the Vue version was 3.2 and we use 3.1 currently